### PR TITLE
feat: write_vectored

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::trace;
 use rustls::Connection;
 use std::io;

--- a/src/connection_stream.rs
+++ b/src/connection_stream.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use rustls::Connection;
 use rustls::IoState;
 use std::io;
@@ -520,10 +521,14 @@ impl tokio::io::AsyncWrite for ConnectionStream {
 
   fn poll_write_vectored(
     self: Pin<&mut Self>,
-    _cx: &mut Context<'_>,
-    _bufs: &[futures::io::IoSlice<'_>],
+    cx: &mut Context<'_>,
+    bufs: &[futures::io::IoSlice<'_>],
   ) -> Poll<Result<usize, io::Error>> {
-    unimplemented!()
+    ConnectionStream::poll_write_vectored(self.get_mut(), cx, bufs)
+  }
+
+  fn is_write_vectored(&self) -> bool {
+    true
   }
 
   fn poll_flush(
@@ -555,7 +560,6 @@ mod tests {
   use rustls::ClientConnection;
   use rustls::ServerConnection;
   use std::time::Duration;
-
   use tokio::io::AsyncWriteExt;
   use tokio::spawn;
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use rustls::Connection;
 use std::io;
 use std::io::ErrorKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod tests {
 
   pub type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-  struct UnsafeVerifier {}
+  pub struct UnsafeVerifier {}
 
   impl ServerCertVerifier for UnsafeVerifier {
     fn verify_server_cert(
@@ -81,7 +81,7 @@ mod tests {
     }
   }
 
-  fn certificate() -> Certificate {
+  pub fn certificate() -> Certificate {
     let buf_read: &mut dyn BufRead =
       &mut &include_bytes!("testdata/localhost.crt")[..];
     let cert = rustls_pemfile::read_one(buf_read)
@@ -95,7 +95,7 @@ mod tests {
     }
   }
 
-  fn private_key() -> PrivateKey {
+  pub fn private_key() -> PrivateKey {
     let buf_read: &mut dyn BufRead =
       &mut &include_bytes!("testdata/localhost.key")[..];
     let cert = rustls_pemfile::read_one(buf_read)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -950,6 +950,19 @@ pub(super) mod tests {
     Ok(())
   }
 
+  /// Test that a flush before a handshake completes works.
+  #[tokio::test]
+  // #[ntest::timeout(60000)]
+  async fn test_flush_before_handshake() -> TestResult {
+    let (mut server, mut client) =
+      tls_pair().await;
+    server.write_all(b"hello?").await.unwrap();
+    server.flush().await.unwrap();
+    let mut buf = [0; 6];
+    assert_eq!(6, client.read_exact(&mut buf).await.unwrap());
+    Ok(())
+  }
+
   /// Test that the handshake works, and we get the correct ALPN negotiated values.
   #[tokio::test]
   #[ntest::timeout(60000)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,19 +1,15 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use crate::connection_stream::ConnectionStream;
-
 use crate::handshake::handshake_task_internal;
 use crate::trace;
 use crate::TestOptions;
 use futures::future::poll_fn;
-
+use futures::task::noop_waker_ref;
 use futures::task::Context;
 use futures::task::Poll;
-
 use futures::task::Waker;
 use futures::FutureExt;
-
-use futures::task::noop_waker_ref;
 use rustls::ClientConfig;
 use rustls::ClientConnection;
 use rustls::Connection;
@@ -25,22 +21,18 @@ use std::fmt::Debug;
 use std::io;
 use std::io::ErrorKind;
 use std::io::Write;
-use tokio::task::JoinError;
-
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-
 use std::task::ready;
-
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tokio::io::ReadBuf;
 use tokio::net::TcpStream;
 use tokio::spawn;
-
 use tokio::sync::watch;
+use tokio::task::JoinError;
 use tokio::task::JoinHandle;
 
 #[derive(Clone, Default)]
@@ -671,6 +663,7 @@ impl Drop for TlsStream {
 #[cfg(test)]
 pub(super) mod tests {
   use super::*;
+  use crate::tests::expect_io_error;
   use futures::stream::FuturesUnordered;
   use futures::FutureExt;
   use futures::StreamExt;
@@ -689,7 +682,6 @@ pub(super) mod tests {
   use tokio::io::AsyncWriteExt;
   use tokio::net::TcpListener;
   use tokio::net::TcpSocket;
-
   use tokio::spawn;
 
   type TestResult = Result<(), std::io::Error>;
@@ -892,13 +884,6 @@ pub(super) mod tests {
 
   async fn tls_pair_handshake() -> (TlsStream, TlsStream) {
     tls_pair_handshake_buffer_size(None, None).await
-  }
-
-  fn expect_io_error<T: std::fmt::Debug>(
-    e: Result<T, io::Error>,
-    kind: io::ErrorKind,
-  ) {
-    assert_eq!(e.expect_err("Expected error").kind(), kind);
   }
 
   async fn expect_eof_read(stm: &mut TlsStream) {

--- a/src/system_test/fastwebsockets.rs
+++ b/src/system_test/fastwebsockets.rs
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use std::num::NonZeroUsize;
 
 use fastwebsockets::FragmentCollectorRead;

--- a/src/system_test/fastwebsockets.rs
+++ b/src/system_test/fastwebsockets.rs
@@ -13,19 +13,28 @@ const LARGE_PAYLOAD: [u8; 48 * 1024] = [0xff; 48 * 1024];
 const SMALL_PAYLOAD: [u8; 16] = [0xff; 16];
 
 #[rstest]
-#[case(false, false, false)]
-#[case(false, false, true)]
-#[case(false, true, false)]
-#[case(false, true, true)]
-#[case(true, false, false)]
-#[case(true, false, true)]
-#[case(true, true, false)]
-#[case(true, true, true)]
+#[case(false, false, false, false)]
+#[case(false, false, false, true)]
+#[case(false, false, true, false)]
+#[case(false, false, true, true)]
+#[case(false, true, false, false)]
+#[case(false, true, false, true)]
+#[case(false, true, true, false)]
+#[case(false, true, true, true)]
+#[case(true, false, false, false)]
+#[case(true, false, false, true)]
+#[case(true, false, true, false)]
+#[case(true, false, true, true)]
+#[case(true, true, false, false)]
+#[case(true, true, false, true)]
+#[case(true, true, true, false)]
+#[case(true, true, true, true)]
 #[tokio::test]
 async fn test_fastwebsockets(
   #[case] handshake: bool,
   #[case] buffer_limit: bool,
   #[case] large_payload: bool,
+  #[case] use_writev: bool,
 ) {
   let payload = if large_payload {
     LARGE_PAYLOAD.as_slice()
@@ -45,9 +54,13 @@ async fn test_fastwebsockets(
     server.handshake().await.expect("failed handshake");
   }
 
-  let a = tokio::spawn(async {
+  let a = tokio::spawn(async move {
     let mut ws = WebSocket::after_handshake(server, Role::Server);
     ws.set_auto_close(true);
+    if use_writev {
+      ws.set_writev(true);
+      ws.set_writev_threshold(0);
+    }
     for i in 0..1000 {
       println!("send {i}");
       ws.write_frame(Frame::binary(Payload::Borrowed(payload)))
@@ -62,8 +75,12 @@ async fn test_fastwebsockets(
     let frame = ws.read_frame().await.expect("failed to read");
     assert_eq!(frame.opcode, OpCode::Close);
   });
-  let b = tokio::spawn(async {
+  let b = tokio::spawn(async move {
     let mut ws = WebSocket::after_handshake(client, Role::Client);
+    if use_writev {
+      ws.set_writev(true);
+      ws.set_writev_threshold(0);
+    }
     ws.set_auto_close(true);
     for i in 0..1000 {
       println!("recv {i}");

--- a/src/system_test/mod.rs
+++ b/src/system_test/mod.rs
@@ -1,1 +1,2 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 mod fastwebsockets;


### PR DESCRIPTION
Adds a fast write_vectored path to TlsStream. Also fixes a bug with flush-before-handshake.