### PR TITLE
fix: ensure that trace has no side-effects when disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "fastwebsockets",
  "futures",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,9 @@ struct TestOptions {
 
 macro_rules! trace {
   ($($args:expr),+) => {
-    #[cfg(feature="trace")]
+    if false && cfg!(feature="trace")
     {
       println!($($args),+);
-    }
-    #[cfg(not(feature="trace"))]
-    {
-      format!($($args),+);
     }
   };
 }


### PR DESCRIPTION
The `trace!` macro was accidentally doing work even when disabled.