### PR TITLE
fix: don't lock up if handshake fails in acceptor

### DIFF
--- a/examples/ssl_trace.rs
+++ b/examples/ssl_trace.rs
@@ -1,6 +1,8 @@
-use rustls::client::danger::{ServerCertVerified, ServerCertVerifier};
+use rustls::client::danger::ServerCertVerified;
+use rustls::client::danger::ServerCertVerifier;
 use rustls::pki_types::ServerName;
-use rustls::{ClientConfig, ClientConnection};
+use rustls::ClientConfig;
+use rustls::ClientConnection;
 use rustls_tokio_stream::TlsStream;
 use std::env;
 use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@ mod stream;
 #[cfg(test)]
 mod system_test;
 
+pub use stream::ServerConfigProvider;
 pub use stream::TlsHandshake;
 pub use stream::TlsStream;
 pub use stream::TlsStreamRead;
 pub use stream::TlsStreamWrite;
-pub use stream::ServerConfigProvider;
 
 /// Re-export the version of rustls we are built on
 pub use rustls;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1382,7 +1382,7 @@ pub(super) mod tests {
 
   /// Test that a flush before a handshake completes works.
   #[tokio::test]
-  // #[ntest::timeout(60000)]
+  #[ntest::timeout(60000)]
   async fn test_flush_before_handshake() -> TestResult {
     let (mut server, mut client) = tls_pair().await;
     server.write_all(b"hello?").await.unwrap();
@@ -1480,7 +1480,7 @@ pub(super) mod tests {
 
   /// Test that the handshake fails, and we get the correct errors on both ends.
   #[tokio::test]
-  // #[ntest::timeout(60000)]
+  #[ntest::timeout(60000)]
   async fn test_client_server_alpn_mismatch() -> TestResult {
     let (mut server, mut client) =
       tls_pair_alpn(&["a"], None, &["b"], None).await;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1442,7 +1442,7 @@ pub(super) mod tests {
   #[case("b")]
   #[case("c")]
   #[tokio::test]
-  // #[ntest::timeout(60000)]
+  #[ntest::timeout(60000)]
   async fn test_client_server_alpn_acceptor(
     #[case] alpn: &'static str,
   ) -> TestResult {


### PR DESCRIPTION
If the accept process failed for any reason, we'd fail to notify that the handshake completed unsuccessfully.