### PR TITLE
Allow access to underlying connection after handshake

### DIFF
--- a/src/connection_stream.rs
+++ b/src/connection_stream.rs
@@ -104,6 +104,10 @@ impl ConnectionStream {
     (Arc::try_unwrap(self.tcp).unwrap(), self.tls)
   }
 
+  pub fn connection(&self) -> &Connection {
+    &self.tls
+  }
+
   pub(crate) fn tcp_stream(&self) -> &Arc<TcpStream> {
     &self.tcp
   }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -433,6 +433,14 @@ impl TlsStream {
     (read, write)
   }
 
+  /// If the stream is open, returns the underlying rustls connection.
+  pub fn connection(&self) -> Option<&rustls::Connection> {
+    match &self.state {
+      TlsStreamState::Open(stm) => Some(stm.connection()),
+      _ => None,
+    }
+  }
+
   pub async fn into_inner(mut self) -> io::Result<(TcpStream, Connection)> {
     poll_fn(|cx| self.poll_pending_handshake(cx)).await?;
     match std::mem::replace(&mut self.state, TlsStreamState::Closed) {
@@ -489,6 +497,9 @@ impl TlsStream {
     &mut self,
     cx: &mut Context,
   ) -> Poll<io::Result<TlsHandshake>> {
+    // Transition to the open state if necessary
+    ready!(self.poll_pending_handshake(cx)?);
+
     // TODO(mmastrac): Handshake shouldn't need to be cloned
     match &*self.handshake.handshake.lock().unwrap() {
       None => {
@@ -1615,6 +1626,25 @@ pub(super) mod tests {
     });
     a.await?;
     b.await?;
+
+    Ok(())
+  }
+
+  /// Test that the handshake fails, and we get the correct errors on both ends.
+  #[tokio::test]
+  #[ntest::timeout(60000)]
+  async fn test_client_server_raw_connection() -> TestResult {
+    let (mut server, mut client) =
+      tls_pair_alpn(&["a"], None, &["a"], None).await;
+
+    assert!(server.connection().is_none());
+    assert!(client.connection().is_none());
+
+    server.handshake().await?;
+    client.handshake().await?;
+
+    assert!(server.connection().is_some());
+    assert!(client.connection().is_some());
 
     Ok(())
   }


### PR DESCRIPTION
Some post-handshake fields are challenging to expose, ie: the actual certificates that were agreed to in the handshake.

We can expose the `rustls::Connection` safely in the `TlsStream` to get access to these certificates and other potentially interesting data. There's no way to expose them from the read and write halves right now, or even during the handshake, but at least unsplit `TlsStream`s will be able to yield that data.

As part of this change, we also transition the `TlsStream` into the open state after `poll_handshake` is successful, which guarantees that 1) the connection is available, and 2) any pre-handshake buffered data has been flushed to the TLS layer. 