### PR TITLE
Don't unsafely read buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.7"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "log",
  "once_cell",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.5.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-tokio-stream"
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ socket2 = "0.5"
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "full" ] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12", "ring"] }
+rustls = { version = "0.23.25", default-features = false, features = ["logging", "std", "tls12", "ring"] }
 rustls-pemfile = "2.0.0"
 ntest = "0.9"
 rstest = "0.18"


### PR DESCRIPTION
`rustls` recently added new plaintext buffer access functions that allow for safely appending to a tokio `ReadBuf`.

The original implementation was technically not sound, though it never caused any issues, because it transmuted a MaybeUninit buffer to a &mut [u8]. Unfortunately at the time, this was the only real way to read data in a performant way. This _could_ potentially cause miscompilations in certain cases, though I never personally saw that occur. 

Instead of doing the unsafe thing, we bump rustls to the latest version and use the new `fill_buf` method along with `put_slice`. To ensure we don't lose performance, we will read as much plaintext as we can each time through the try_read loop.

A new debug assertion ensures we return the correct number of bytes read.
