### PR TITLE
Clean up async stream implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "derive-io"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cc7f4740088458993d183a200fe56e62378736f94bf0e2dd45807407e7bb94"
+dependencies = [
+ "derive-io-macros",
+ "tokio",
+]
+
+[[package]]
+name = "derive-io-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0a1bd7eeab72097740967d03d53db5fbaf8e3c0dd471ebdefa43ce445a20a6"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +597,7 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 name = "rustls-tokio-stream"
 version = "0.6.0"
 dependencies = [
+ "derive-io",
  "fastwebsockets",
  "futures",
  "ntest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ rustls = { version = "0.23", default-features = false, features = ["std"] }
 futures = "0.3"
 # SockRef
 socket2 = "0.5"
+# Simplifies impl Async{Read,Write}
+derive-io = { version = "=0.4.1", features = ["tokio"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "full" ] }


### PR DESCRIPTION
We were previously implementing AsyncRead/AsyncWrite in a few places that were just mechanical delegations to an underlying stream. This replaces those manual implementations with `derive_io::AsyncRead` and `derive_io::AsyncWrite` which cleans things up a bit.

A few additional cleanups as well: `use super::*` in `stream.rs` was expanded out to avoid method conflicts, and `AsyncReadExt`/`AsyncWriteExt` methods were used in tests to reduce `poll_fn` calls. 

No functional changes, just reducing boilerplate to make the code easier to parse.